### PR TITLE
Refactor margin account indexing

### DIFF
--- a/utils/types.ts
+++ b/utils/types.ts
@@ -47,16 +47,22 @@ export interface Surface {
   interest_rate: number;
 }
 
-export interface MarginAccountPosition {
+export interface MarginAccount {
   timestamp: number;
   slot: number;
+  margin_account_address: string;
+  underlying: string;
   owner_pub_key: string;
-  expiry_timestamp: number;
   force_cancel_flag: boolean;
   balance: number;
   rebalance_amount: number;
+  positions: MarginAccountPosition[];
+}
+
+export interface MarginAccountPosition {
+  expiry_timestamp: number;
   market_index: number;
-  position: number;
+  size: number;
   cost_of_trades: number;
   closing_orders: number;
   opening_orders_bid: number;


### PR DESCRIPTION
Changes:
- Changed MarginAccount type, such that positions is no longer flattened
- Added in additional missing fields and fixed erroneous fields

Proposed data eg:

```{
  timestamp: 1650958827,
  slot: 131379675,
  underlying: 'SOL',
  margin_account_address: '2qMaHVzUYku2BFWYUPNNivraMye6PLSVAM1bcug4TzCK',
  owner_pub_key: 'urmomavcGazScDVacUEddcSVEWNqT86frNHn5PhZ3Sa',
  balance: 71037.888173,
  rebalance_amount: 0,
  force_cancel_flag: false,
  positions: [
    {
      market_index: 0,
      expiry_timestamp: 1651824000,
      size: -0.331,
      cost_of_trades: 11.875399,
      closing_orders: 0.331,
      opening_orders_bid: 27.72,
      opening_orders_ask: 14.073
    },
    {
      market_index: 1,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.075,
      opening_orders_ask: 14.077
    },
    {
      market_index: 2,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.075,
      opening_orders_ask: 14.081
    },
    {
      market_index: 3,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.073,
      opening_orders_ask: 14.077
    },
    {
      market_index: 4,
      expiry_timestamp: 1651824000,
      size: -0.068,
      cost_of_trades: 1.02816,
      closing_orders: 0.068,
      opening_orders_bid: 14.009,
      opening_orders_ask: 14.077
    },
    {
      market_index: 5,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 6,
      expiry_timestamp: 1651824000,
      size: -285.24,
      cost_of_trades: 672.795588,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 7,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 8,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 9,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 10,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 11,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 12,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 13,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 14,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 15,
      expiry_timestamp: 1651824000,
      size: -285.24,
      cost_of_trades: 948.480048,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 16,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 17,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 29.099,
      opening_orders_ask: 29.081
    },
    {
      market_index: 18,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 29.099,
      opening_orders_ask: 14.077
    },
    {
      market_index: 19,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 29.099,
      opening_orders_ask: 14.077
    },
    {
      market_index: 20,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.081,
      opening_orders_ask: 14.073
    },
    {
      market_index: 21,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.081,
      opening_orders_ask: 14.077
    },
    {
      market_index: 22,
      expiry_timestamp: 1651824000,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 23,
      expiry_timestamp: 1651219200,
      size: 0.213,
      cost_of_trades: 5.96848,
      closing_orders: 0.213,
      opening_orders_bid: 55.602,
      opening_orders_ask: 41.659
    },
    {
      market_index: 24,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 28.047,
      opening_orders_ask: 28.083
    },
    {
      market_index: 25,
      expiry_timestamp: 1651219200,
      size: -0.4,
      cost_of_trades: 11.324,
      closing_orders: 0.4,
      opening_orders_bid: 13.689,
      opening_orders_ask: 14.081
    },
    {
      market_index: 26,
      expiry_timestamp: 1651219200,
      size: 0.079,
      cost_of_trades: 1.42042,
      closing_orders: 0.079,
      opening_orders_bid: 41.841,
      opening_orders_ask: 27.797
    },
    {
      market_index: 27,
      expiry_timestamp: 1651219200,
      size: -3,
      cost_of_trades: 56.219548,
      closing_orders: 3,
      opening_orders_bid: 39.06,
      opening_orders_ask: 28.047
    },
    {
      market_index: 28,
      expiry_timestamp: 1651219200,
      size: -6.665,
      cost_of_trades: 84.74004,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 29,
      expiry_timestamp: 1651219200,
      size: -1,
      cost_of_trades: 2.9,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 30,
      expiry_timestamp: 1651219200,
      size: -285.24,
      cost_of_trades: 484.679808,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 31,
      expiry_timestamp: 1651219200,
      size: -285.24,
      cost_of_trades: 302.981928,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 32,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 33,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 34,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 35,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 36,
      expiry_timestamp: 1651219200,
      size: -461.933,
      cost_of_trades: 121.597655,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 37,
      expiry_timestamp: 1651219200,
      size: -1,
      cost_of_trades: 0.74,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 38,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 39,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    },
    {
      market_index: 40,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 29.073,
      opening_orders_ask: 29.101
    },
    {
      market_index: 41,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 74.064,
      opening_orders_ask: 29.075
    },
    {
      market_index: 42,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.089,
      opening_orders_ask: 29.105
    },
    {
      market_index: 43,
      expiry_timestamp: 1651219200,
      size: 0,
      cost_of_trades: 0,
      closing_orders: 0,
      opening_orders_bid: 14.081,
      opening_orders_ask: 44.125
    },
    {
      market_index: 44,
      expiry_timestamp: 1651219200,
      size: -1.329,
      cost_of_trades: 67.5562,
      closing_orders: 1.329,
      opening_orders_bid: 27.768,
      opening_orders_ask: 14.081
    },
    {
      market_index: 45,
      expiry_timestamp: 1651219200,
      size: -0.388,
      cost_of_trades: 39.38976,
      closing_orders: 0,
      opening_orders_bid: 0,
      opening_orders_ask: 0
    }
  ]
}