### PR TITLE
Fix buffer-layout package issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "@project-serum/serum": "0.13.55",
+    "@solana/buffer-layout": "4.0.0",
     "@solana/web3.js": "^1.18.0",
     "@zetamarkets/flex-sdk": "^0.4.3",
     "@zetamarkets/sdk": "^0.10.6",
     "aws-sdk": "^2.1047.0",
-    "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^4.4.3",
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.6.1"
+  },
+  "resolutions": {
+    "@solana/buffer-layout": "4.0.0"
   }
 }


### PR DESCRIPTION
Quick one to fix "TypeError: fields must be array of Layout instances". Eg: https://ap-southeast-1.console.aws.amazon.com/ecs/v2/clusters/zetadex-program-account-indexer-cluster/tasks/1428432d7f7e47819ef79fbd5ede7925/logs?region=ap-southeast-1