### PR TITLE
Fix builds up

### DIFF
--- a/greeks-update-processing.ts
+++ b/greeks-update-processing.ts
@@ -149,7 +149,7 @@ export const collectPricingData = async () => {
       for (var k = 0; k < marginAccounts.length; k++) {
         let acc = marginAccounts[k].account as programTypes.MarginAccount;
         totalPositions += utils.convertNativeBNToDecimal(
-          acc.positions[marketIndex].position.abs(),
+          acc.productLedgers[marketIndex].position.size.abs(),
           3
         );
       }

--- a/margin-account-processing.ts
+++ b/margin-account-processing.ts
@@ -29,26 +29,27 @@ export const collectMarginAccountData = () => {
       const marginAccount = data.account;
       let marginAccountPositions: MarginAccountPosition[] = [];
 
-      for (let i = 0; i < marginAccount.positions.length; i++) {
-        let position = marginAccount.positions[i];
+      for (let i = 0; i < marginAccount.productLedgers.length; i++) {
+        let ledger = marginAccount.productLedgers[i];
+        let position = ledger.position;
         const marketIndex = i;
         const expiryIndex = Math.floor(marketIndex / 23);
         let expiry = marginAccount.seriesExpiry[expiryIndex].toNumber();
         let marginAccountPosition: MarginAccountPosition = {
           market_index: marketIndex,
           expiry_timestamp: expiry,
-          size: convertNativeBNToDecimal(position.position, POSITION_PRECISION),
+          size: convertNativeBNToDecimal(position.size, POSITION_PRECISION),
           cost_of_trades: convertNativeBNToDecimal(position.costOfTrades),
           closing_orders: convertNativeBNToDecimal(
-            position.closingOrders,
+            ledger.orderState.closingOrders,
             POSITION_PRECISION
           ),
           opening_orders_bid: convertNativeBNToDecimal(
-            position.openingOrders[0],
+            ledger.orderState.openingOrders[0],
             POSITION_PRECISION
           ),
           opening_orders_ask: convertNativeBNToDecimal(
-            position.openingOrders[1],
+            ledger.orderState.openingOrders[1],
             POSITION_PRECISION
           ),
         };

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "@project-serum/serum": "0.13.55",
-    "@solana/web3.js": "^1.18.0",
-    "@zetamarkets/flex-sdk": "^0.4.3",
-    "@zetamarkets/sdk": "^0.10.6",
+    "@solana/buffer-layout": "4.0.0",
+    "@solana/web3.js": "^1.36.0",
+    "@zetamarkets/flex-sdk": "^0.5.1",
+    "@zetamarkets/sdk": "^0.14.1",
     "aws-sdk": "^2.1047.0",
-    "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^4.4.3",
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.6.1"
+  },
+  "resolutions": {
+    "@solana/buffer-layout": "4.0.0"
   }
 }


### PR DESCRIPTION
This PR fixes a few separate build-related issues:
1. "TypeError: fields must be array of Layout instances" is fixed by the package.json buffer-layout bits and pieces
2. Versions in package.json are bumped up, mainly the SDK.
3. New SDK version caused some syntax issues with positions/productLedgers, which are resolved.

I ran this locally with a completely fresh git clone, and it works fine (I bumped the 30/60 min timers down to ~5 mins to make all the functions run)